### PR TITLE
bug fix, already claimed coordinate

### DIFF
--- a/cn/src/main/java/org/cloudname/zk/ClaimedCoordinate.java
+++ b/cn/src/main/java/org/cloudname/zk/ClaimedCoordinate.java
@@ -265,8 +265,7 @@ public class ClaimedCoordinate implements Watcher, ZkUserInterface {
                     final byte[] serverData = getZooKeeper().getData(path, false, stat);
                     final String serverDataString = new String(serverData, Util.CHARSET_NAME);
                     final String ourDataString = zkCoordinateData.snapshot().serialize();
-                    if (getZooKeeper().getSessionId() == stat.getEphemeralOwner() &&
-                            serverDataString.equals(ourDataString)) {
+                    if (getZooKeeper().getSessionId() == stat.getEphemeralOwner()) {
                         getZooKeeper().delete(path, lastStatusVersion);
                     }
                 } catch (InterruptedException e) {


### PR DESCRIPTION
...changed, the system might get into a state where it thinks that it does not own the coordinate, even though the PIDs are fine.

Make it more aggresive so it deletes the coordinate in this case and resolve to a good state.
