### PR TITLE
Bugfix, avoid ConcurrentModificationException when it.next() is called a...

### DIFF
--- a/cn/src/main/java/org/cloudname/zk/DynamicExpression.java
+++ b/cn/src/main/java/org/cloudname/zk/DynamicExpression.java
@@ -266,7 +266,7 @@ class DynamicExpression implements Watcher, TrackedCoordinate.ExpressionResolver
                 String key = endpointEntry.getKey();
 
                 if (! newEndpointsByName.containsKey(key)) {
-                    clientPicture.remove(key);
+                    it.remove();
                     clientCallback.endpointEvent(
                             Resolver.ResolverListener.Event.REMOVED_ENDPOINT, endpointEntry.getValue());
                 }


### PR DESCRIPTION
...fter clientPicture.remove().
