### PR TITLE
Use Jackson Mapper 2.0 and drop 1.x support

### DIFF
--- a/a3/pom.xml
+++ b/a3/pom.xml
@@ -55,16 +55,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-core-asl</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.codehaus.jackson</groupId>
-      <artifactId>jackson-mapper-asl</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>
@@ -87,6 +77,18 @@
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>jsr250-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <version>2.0.4</version>
     </dependency>
   </dependencies>
 </project>

--- a/a3/src/main/java/org/cloudname/a3/domain/User.java
+++ b/a3/src/main/java/org/cloudname/a3/domain/User.java
@@ -1,16 +1,15 @@
 package org.cloudname.a3.domain;
 
-import java.util.Set;
-import java.util.Map;
-
 import java.io.IOException;
-
-import org.codehaus.jackson.annotate.JsonCreator;
-import org.codehaus.jackson.annotate.JsonProperty;
-
-import org.codehaus.jackson.map.ObjectMapper;
+import java.util.Map;
+import java.util.Set;
 
 import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /**
  * User domain object.  This is supposed to be immutable which is why
@@ -169,7 +168,9 @@ public class User {
      */
     public String toJson() {
         try {
-            return new ObjectMapper().writeValueAsString(this);
+            final ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JodaModule());
+			return mapper.writeValueAsString(this);
         } catch (IOException e) {
             return null;
         }
@@ -179,7 +180,9 @@ public class User {
      * Create a User instance from a JSON string.
      */
     public static User fromJson(String json) throws IOException {
-        return new ObjectMapper().readValue(json, User.class);
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JodaModule());
+		return mapper.readValue(json, User.class);
     }
 
     @Override

--- a/a3/src/main/java/org/cloudname/a3/domain/UserDB.java
+++ b/a3/src/main/java/org/cloudname/a3/domain/UserDB.java
@@ -1,7 +1,5 @@
 package org.cloudname.a3.domain;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 
 import java.util.Map;
 import java.util.Set;
@@ -14,6 +12,10 @@ import java.util.Collections;
 import java.util.Comparator;
 
 import java.io.IOException;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 /**
  * Extremely simple user database which is simply a collection of
@@ -106,7 +108,8 @@ public class UserDB {
 
         try {
             ObjectMapper mapper = new ObjectMapper();
-            mapper.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
+            mapper.registerModule(new JodaModule());
+            mapper.configure(SerializationFeature.INDENT_OUTPUT, true);
 
             List<User> users = new ArrayList<User>(userMap.values());
 
@@ -129,7 +132,9 @@ public class UserDB {
      */
     public static UserDB fromJson(String json) {
         try {
-            User[] users = new ObjectMapper().readValue(json, User[].class);
+            final ObjectMapper mapper = new ObjectMapper();
+            mapper.registerModule(new JodaModule());
+            User[] users = mapper.readValue(json, User[].class);
             HashMap<String, User> m = new HashMap<String, User>();
             for (User user : users) {
                 m.put(user.getUsername(), user);

--- a/a3/src/main/java/org/cloudname/a3/editor/Editor.java
+++ b/a3/src/main/java/org/cloudname/a3/editor/Editor.java
@@ -12,10 +12,10 @@ import jline.SimpleCompletor;
 import jline.MultiCompletor;
 import jline.NullCompletor;
 
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.JsonParseException;
-
 import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Set;
 import java.util.Map;


### PR DESCRIPTION
This commits replaces the jackson JSON-mapper with
version 2. This enables us to properly use builder
pattern with our beans.

Warning: This might break old clients - I haven't tested wether or not this creates chaos
on projects that use jackson 1.5.
