### PR TITLE
PAYMENT-683 - Reducing number of open files in Archiver

### DIFF
--- a/log/src/main/java/org/cloudname/log/archiver/Archiver.java
+++ b/log/src/main/java/org/cloudname/log/archiver/Archiver.java
@@ -21,7 +21,7 @@ import java.io.IOException;
  * @author borud
  */
 public class Archiver {
-    private static final int MAX_FILES_OPEN = 5;
+    private static final int MAX_FILES_OPEN = 2;
 
     private String service = "";
 


### PR DESCRIPTION
Lowering the value of MAX_FILES_OPEN from 5 to 2 in order to reduce
the latency for slot files to be available on S3 (since they cannot be
uploaded until they are closed).
