### PR TITLE
CloudnameLock bug fix

### DIFF
--- a/cn/src/main/java/org/cloudname/zk/ZkCloudnameLock.java
+++ b/cn/src/main/java/org/cloudname/zk/ZkCloudnameLock.java
@@ -46,6 +46,7 @@ public class ZkCloudnameLock implements CloudnameLock {
     private String lockPath;
 
     private static final Logger log = Logger.getLogger(ZkCloudnameLock.class.getName());
+    private static final int EPHEMERAL_NODE_NUMBER_LENGTH = 10;
 
     /**
      * Prepare a CloudnameLock object.
@@ -206,7 +207,7 @@ public class ZkCloudnameLock implements CloudnameLock {
         String nodeToWatch = "";
         int nodeNumberToWatch = -1;
         for (final String child : children) {
-            if (!child.startsWith(this.lockName)) {
+            if (!getNodeName(child).equals(lockName)) {
                 continue;
             }
             final int childNumber = getNodeNumber(child);
@@ -301,6 +302,14 @@ public class ZkCloudnameLock implements CloudnameLock {
     private int getNodeNumber(String node) {
         //TODO (acidmoose): Consider replacing with regex
         return Integer.parseInt(node.substring(node.indexOf(lockName) + lockName.length(), node.length()));
+    }
+
+    /**
+     * Get the name of a sequential ephemeral node. Node path looks like
+     * this "/cn/pathToLock/lockname000000001", and this method returns "lockname" in this case.
+     */
+    private String getNodeName(String node) {
+        return node.substring(0, node.length() - EPHEMERAL_NODE_NUMBER_LENGTH);
     }
 
     private String createAndGetLockPath() throws InterruptedException, KeeperException {

--- a/cn/src/test/java/org/cloudname/zk/ZkCloudnameLockTest.java
+++ b/cn/src/test/java/org/cloudname/zk/ZkCloudnameLockTest.java
@@ -288,6 +288,27 @@ public class ZkCloudnameLockTest {
     }
 
     /**
+     * Check that a lock with a partial name match to another lock behaves correctly.
+     * @throws Exception
+     */
+    @Test
+    public void testNamePrefix () throws Exception {
+        cn = new ZkCloudname.Builder().setConnectString("localhost:" + zkport).build().connect();
+        final Coordinate coordinate = Coordinate.parse("1.service.user.cell");
+        cn.createCoordinate(coordinate);
+        final ServiceHandle serviceHandle = cn.claim(coordinate);
+        final CloudnameLock.Scope scope = CloudnameLock.Scope.SERVICE;
+        CloudnameLock lock1 = serviceHandle.getCloudnameLock(scope, "aaa");
+        CloudnameLock lock2 = serviceHandle.getCloudnameLock(scope, "aaabbb");
+
+        assertTrue("Did not get lock.", lock2.tryLock());
+        assertTrue("Did not get lock.", lock1.tryLock());
+
+        lock1.release();
+        lock2.release();
+    }
+
+    /**
      * Class simulates a shared resource that can not be used by more than one at a time.
      */
     private class Work {


### PR DESCRIPTION
Previously did not work if the name of a lock started with the same string as another lock.
