### PR TITLE
Skip required options if version is parsed

### DIFF
--- a/flags/src/main/java/org/cloudname/flags/Flags.java
+++ b/flags/src/main/java/org/cloudname/flags/Flags.java
@@ -1,11 +1,6 @@
 package org.cloudname.flags;
 
-import joptsimple.OptionParser;
-import joptsimple.OptionSet;
-import joptsimple.OptionSpec;
-
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
@@ -21,6 +16,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.TreeMap;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpec;
 
 
 /**
@@ -340,6 +338,9 @@ public class Flags {
         if (helpFlagged()) {
             return this;
         }
+        if (versionFlagged()) {
+            return this;
+        }
         if (propertiesFlagged()) {
             List<String> files = optionSet.valuesOf(PROPERTIES_FILE);
             ArrayList<String> newArgs = new ArrayList<String>();
@@ -534,7 +535,6 @@ public class Flags {
         final PrintWriter w = new PrintWriter(out);
         w.println(versionString);
         w.flush();
-        w.close();
     }
 
     /**

--- a/flags/src/test/java/org/cloudname/flags/FlagsTest.java
+++ b/flags/src/test/java/org/cloudname/flags/FlagsTest.java
@@ -1,16 +1,14 @@
 package org.cloudname.flags;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
-
 import junit.framework.Assert;
-
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class for Flags.
@@ -141,6 +139,7 @@ public class FlagsTest {
 
         // Check that printHelp does not crash.
         flags.printHelp(System.out);
+        flags.printVersion(System.out);
     }
 
     /**
@@ -232,6 +231,27 @@ public class FlagsTest {
         Flags flags = new Flags()
         .loadOpts(FlagsRequiredArg.class)
         .parse(new String[]{});
+    }
+
+    /**
+     * Test that --help and --version does not trigger ArgumentException when parsing flags are required.
+     */
+    @Test
+    public void testRequiredArgWithHelp() {
+        try {
+            Flags helpFlags = new Flags()
+                .loadOpts(FlagsRequiredArg.class)
+                .parse(new String[]{"--help"});
+            helpFlags.printHelp(System.out);
+
+            Flags versionFlags = new Flags()
+                .loadOpts(FlagsRequiredArg.class)
+                .parse(new String[]{"--version"});
+            versionFlags.printVersion(System.out);
+        } catch (Exception e) {
+            e.printStackTrace();
+            assertFalse("Should not throw exceptions", true);
+        }
     }
 
     /**


### PR DESCRIPTION
If version was parsed the default behaviour is to print the version string,
but this is not done if there are required flags that have not been parsed.
This skips these required flags (so no IllegalArgumentException is thrown) if the version option is parsed.
