### PR TITLE
It is important to check returnvalue of file.mkdirs() since it will

### DIFF
--- a/log/src/main/java/org/cloudname/log/archiver/Slot.java
+++ b/log/src/main/java/org/cloudname/log/archiver/Slot.java
@@ -98,7 +98,11 @@ public class Slot {
 
         // Make sure directory exists
         if (!parentDir.exists()) {
-            parentDir.mkdirs();
+            if (!parentDir.mkdirs()) {
+                throw new ArchiverException("Could not create folder '"
+                        + parentDir.getAbsolutePath() + "', hence slot-file logging will fail. " +
+                        "Does your user have sufficient permissions to create folders?");
+            }
         }
 
         File foundFile = null;


### PR DESCRIPTION
return false when it fails.

If it fails, a NullPointerException will occur on the line with
'for (final File f : parentDir.listFiles()) {'. Kind of difficult to
understand why. This exception should be pretty clear.

We've experienced this using cloudname in our application, because
the user did not have permission to create folders.