### PR TITLE
Fail when we are not able to create slot directory

### DIFF
--- a/log/src/main/java/org/cloudname/log/archiver/Slot.java
+++ b/log/src/main/java/org/cloudname/log/archiver/Slot.java
@@ -98,7 +98,9 @@ public class Slot {
 
         // Make sure directory exists
         if (!parentDir.exists()) {
-            parentDir.mkdirs();
+            if (!parentDir.mkdirs()) {
+                throw new IOException("Could not create the non-existing directory " + parentDir.toString());
+            }
         }
 
         File foundFile = null;


### PR DESCRIPTION
When we get a new slot for a logfile we have to ensure that the
directory of the slotfile path exists, if it doesnt exist we try to
create the directories. We already did all of this, but we did not check
if the creation of the directories was successful. This commit fails we
are unable to create all of the directories of a slotfile.