### PR TITLE
Add Priority annotation

### DIFF
--- a/a3/pom.xml
+++ b/a3/pom.xml
@@ -76,6 +76,12 @@
 
     <dependency>
       <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
       <artifactId>jsr250-api</artifactId>
     </dependency>
 
@@ -88,5 +94,13 @@
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-joda</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <version>2.0</version>
+    </dependency>
+
   </dependencies>
+
 </project>

--- a/a3/src/main/java/org/cloudname/a3/jaxrs/JerseyRequestFilter.java
+++ b/a3/src/main/java/org/cloudname/a3/jaxrs/JerseyRequestFilter.java
@@ -9,6 +9,8 @@ import com.sun.jersey.spi.container.ContainerRequestFilter;
 
 import java.security.Principal;
 
+import javax.annotation.Priority;
+import javax.ws.rs.Priorities;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.core.UriInfo;
@@ -51,6 +53,7 @@ import org.cloudname.a3.domain.User;
  *
  * @see JerseyRoleBasedAccessControlResourceFilterFactory
  */
+@Priority(Priorities.AUTHENTICATION)
 public class JerseyRequestFilter implements ContainerRequestFilter {
 
     private static final String REALM = "Schmealm";


### PR DESCRIPTION
To ensure that jersey will invoke this filter
before any filters that need the UserPrincipal,
add an annotation that tells it to do so.