### PR TITLE
Log slot numbering based on first log event timestamp.

### DIFF
--- a/log/src/main/java/org/cloudname/log/archiver/Slot.java
+++ b/log/src/main/java/org/cloudname/log/archiver/Slot.java
@@ -91,9 +91,10 @@ public class Slot {
      * Find the next slot file to write to.
      *
      * @return a File instance that points to the next slot file
+     * @param eventTimestamp the timestamp of the event you are trying to find a new slot for.
      */
-    private File findNextSlotFile() throws IOException {
-        final File file = new File(nameForTimestamp(System.currentTimeMillis()));
+    private File findNextSlotFile(final long eventTimestamp) throws IOException {
+        final File file = new File(nameForTimestamp(eventTimestamp));
         final File parentDir = file.getParentFile();
 
         // Make sure directory exists
@@ -164,7 +165,7 @@ public class Slot {
                 throw new IllegalStateException("Slot was closed");
             }
 
-            currentFile = findNextSlotFile();
+            currentFile = findNextSlotFile(event.getTimestamp());
 
             // Pick up number of bytes in file
             numBytesInFile = currentFile.length();


### PR DESCRIPTION
Log slots were postfixed with a creation timestamp, which should
always be a few milliseconds off the timestamp of the first log
event. Instead of this postfix with the first log timestamp.
This also fixes a test case where we used System.currentMillis
instead of a TimeProvider to set the previous name scheme.