### PR TITLE
Flags through properties file gets no special treatment.

### DIFF
--- a/flags/src/main/java/org/cloudname/flags/Flags.java
+++ b/flags/src/main/java/org/cloudname/flags/Flags.java
@@ -351,8 +351,8 @@ public class Flags {
                     props.load(stream);
                     for (Enumeration<?> keys = props.propertyNames(); keys.hasMoreElements();) {
                         String flagName = (String) keys.nextElement();
-                        if (!options.containsKey(flagName) || optionSet.hasArgument(flagName)) {
-                            //Properties contains something not in options or is already set by commandline argument
+                        if (optionSet.hasArgument(flagName)) {
+                            //Properties contains something already set by commandline argument
                             //Command line argument takes precedence over properties file
                             continue;
                         }


### PR DESCRIPTION
Handlig of argument, wether it's from the command line or via
a properties file, should be handled in the same way. If you
expect a certain result from the command line, you should be
expecting the same result of you simply put that argument in
a properties file.

- Can now do "help" and "version". There are no big issues in
allowing the use of those flags through that file.
- Will now crash if an argument is given for which its Flag
counterpart does not exist.