### PR TITLE
Flags through properties file gets no special treatment.

### DIFF
--- a/flags/src/main/java/org/cloudname/flags/Flags.java
+++ b/flags/src/main/java/org/cloudname/flags/Flags.java
@@ -351,13 +351,16 @@ public class Flags {
                     props.load(stream);
                     for (Enumeration<?> keys = props.propertyNames(); keys.hasMoreElements();) {
                         String flagName = (String) keys.nextElement();
-                        if (!options.containsKey(flagName) || optionSet.hasArgument(flagName)) {
-                            //Properties contains something not in options or is already set by commandline argument
+                        if (optionSet.hasArgument(flagName)) {
+                            //Properties contains something already set by commandline argument
                             //Command line argument takes precedence over properties file
                             continue;
                         }
                         newArgs.add("--" + flagName);
-                        newArgs.add(props.getProperty(flagName));
+                        String value = props.getProperty(flagName);
+                        if (value != null && ! value.isEmpty()) {
+                            newArgs.add(value);
+                        }
                     }
 
                     stream.close();

--- a/flags/src/test/java/org/cloudname/flags/FlagsPropertiesFile.java
+++ b/flags/src/test/java/org/cloudname/flags/FlagsPropertiesFile.java
@@ -9,4 +9,7 @@ public class FlagsPropertiesFile {
 
     @Flag(name="comments", description = "should not be set")
     static String comments;
+
+    @Flag(name="booleanvalue")
+    static boolean booleanValue = false;
 }

--- a/flags/src/test/java/org/cloudname/flags/FlagsTest.java
+++ b/flags/src/test/java/org/cloudname/flags/FlagsTest.java
@@ -4,7 +4,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import junit.framework.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -17,6 +19,9 @@ import static org.junit.Assert.assertTrue;
  *
  */
 public class FlagsTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     /**
      * Test all supported field types.
@@ -295,19 +300,38 @@ public class FlagsTest {
         File propertiesFile = File.createTempFile("test", "properties");
         propertiesFile.setWritable(true);
         FileOutputStream fio = new FileOutputStream(propertiesFile);
-        String properties = "integer=1\n\n" + "#comments=not included\n" +
-            "not-in-options=abc\n" + "name=myName\n" +
-            "help\n" + "version\n";
+        String properties = "integer=1\n\n"
+                + "#comments=not included\n"
+                + "name=myName\n"
+                + "booleanvalue\n"
+                + "help\n";
         fio.write(properties.getBytes());
         fio.close();
         Flags flags = new Flags()
             .loadOpts(FlagsPropertiesFile.class)
             .parse(new String[]{"--properties-file", propertiesFile.getAbsolutePath()});
-        assertFalse("Help seems to have been called. It should not have been.", flags.helpFlagged());
-        assertFalse("Version seems to have been called. It should not have been.", flags.versionFlagged());
         assertEquals("myName", FlagsPropertiesFile.name);
+        assertTrue(FlagsPropertiesFile.booleanValue);
+        assertTrue(flags.helpFlagged());
         assertEquals(1, FlagsPropertiesFile.integer);
         Assert.assertNull(FlagsPropertiesFile.comments);
+    }
+
+    /**
+     * Test that --properties-file does not accept keys which are not defined as flags
+     */
+    @Test
+    public void testLoadingUndefinedFlagFromPropertiesFile() throws Exception {
+        exception.expect(joptsimple.OptionException.class);
+        File propertiesFile = File.createTempFile("test", "properties");
+        propertiesFile.setWritable(true);
+        FileOutputStream fio = new FileOutputStream(propertiesFile);
+        String properties = "not-in-options=abc\n";
+        fio.write(properties.getBytes());
+        fio.close();
+        new Flags()
+                .loadOpts(FlagsPropertiesFile.class)
+                .parse(new String[]{"--properties-file", propertiesFile.getAbsolutePath()});
     }
 
     /**
@@ -334,8 +358,6 @@ public class FlagsTest {
             .parse(new String[]{"--properties-file", propertiesFile1.getAbsolutePath(),
                                 "--properties-file", propertiesFile2.getAbsolutePath()
             });
-        assertFalse("Help seems to have been called. It should not have been.", flags.helpFlagged());
-        assertFalse("Version seems to have been called. It should not have been.", flags.versionFlagged());
         assertEquals("myName", FlagsPropertiesFile.name);
         assertEquals(1, FlagsPropertiesFile.integer);
         Assert.assertNull(FlagsPropertiesFile.comments);
@@ -360,13 +382,11 @@ public class FlagsTest {
             "help\n" + "version\n";
         fio2.write(properties2.getBytes());
         fio2.close();
-        Flags flags = new Flags()
+        new Flags()
             .loadOpts(FlagsPropertiesFile.class)
             .parse(new String[]{"--properties-file", propertiesFile1.getAbsolutePath() + ';'
                 +propertiesFile2.getAbsolutePath()
             });
-        assertFalse("Help seems to have been called. It should not have been.", flags.helpFlagged());
-        assertFalse("Version seems to have been called. It should not have been.", flags.versionFlagged());
         assertEquals("myName", FlagsPropertiesFile.name);
         assertEquals(1, FlagsPropertiesFile.integer);
         Assert.assertNull(FlagsPropertiesFile.comments);


### PR DESCRIPTION
Handlig of argument, wether it's from the command line or via
a properties file, should be handled in the same way. If you
expect a certain result from the command line, you should be
expecting the same result of you simply put that argument in
a properties file.

- Can now do "help" and "version". There are no big issues in
allowing the use of those flags through that file.
- Will now crash if an argument is given for which its Flag
counterpart does not exist.