### PR TITLE
Simplify core interface

### DIFF
--- a/a3/src/main/java/org/cloudname/a3/A3Client.java
+++ b/a3/src/main/java/org/cloudname/a3/A3Client.java
@@ -77,8 +77,9 @@ public class A3Client
      *
      * @param in an InputStream which contains valid JSON user database.
      * @return an A3Client instance backed by MemoryStorage
-     * @deprecated does not specify how to convert bytes to
-     * characters, use a Reader instead of InputStream.
+     * @deprecated does not specify how to convert bytes to characters, use a Reader instead of
+     *      InputStream.
+     * @throws IOException if there's an error reading from the memory storage
      */
     public static A3Client newMemoryOnlyClient(InputStream in) throws IOException {
         return new A3Client(MemoryStorage.fromInputStream(in));
@@ -90,6 +91,7 @@ public class A3Client
      *
      * @param in a Reader which contains a valid JSON user database.
      * @return an A3Client instance backed by MemoryStorage
+     * @throws IOException if there's an error reading from the storage
      */
     public static A3Client newMemoryOnlyClient(Reader in) throws IOException {
         return new A3Client(MemoryStorage.fromReader(in));

--- a/a3/src/main/java/org/cloudname/a3/domain/ServiceCoordinate.java
+++ b/a3/src/main/java/org/cloudname/a3/domain/ServiceCoordinate.java
@@ -103,8 +103,8 @@ public class ServiceCoordinate {
     /**
      * Get the path prefix for a Service coordinate.
      *
-     * @param namespace {@see getPathPrefix(String,boolean)}
-     * @return
+     * @param namespace THe namespace for the path prefix
+     * @return a ZooKeeper path prefix
      */
     public String getPathPrefix(String namespace) {
         return getPathPrefix(namespace, false);

--- a/a3/src/main/java/org/cloudname/a3/domain/User.java
+++ b/a3/src/main/java/org/cloudname/a3/domain/User.java
@@ -45,7 +45,16 @@ public class User {
      * This constructor is mainly used by Jackson in order to create
      * instances of the User object from JSON.
      *
-     * The Set<String> of roles should be lowercase role names.
+     * The Set[string] of roles should be lowercase role names.
+     *
+     * @param username user name
+     * @param password user's password
+     * @param oldPassword old password for user
+     * @param oldPasswordExpiry expiry date for old password
+     * @param realName User's real name
+     * @param email User's email
+     * @param roles User roles
+     * @param properties User properties
      */
     @JsonCreator
     public User(@JsonProperty("username") String username,
@@ -177,7 +186,9 @@ public class User {
     }
 
     /**
-     * Create a User instance from a JSON string.
+     * @param json JSON String
+     * @return User instance from a JSON string.
+     * @throws IOException if there's an error reading from JSON
      */
     public static User fromJson(String json) throws IOException {
         final ObjectMapper mapper = new ObjectMapper();

--- a/a3/src/main/java/org/cloudname/a3/jaxrs/JerseyRequestFilter.java
+++ b/a3/src/main/java/org/cloudname/a3/jaxrs/JerseyRequestFilter.java
@@ -31,12 +31,12 @@ import org.cloudname.a3.domain.User;
  * (the user might me trying to access a publicly available resource). However if
  * the user is specified but the username or password is wrong then we let the user know.
  *
- * <h4>Dependencies</h4>
+ * <strong>Dependencies</strong>
  * The filter expects an {@link A3Client} instance to be provided by Jersey. For that to work
- * you need to have a @{@link javax.ws.rs.ext.Provider.Provider} creating it available somewhere where Jersey can
+ * you need to have a @{@link javax.ws.rs.ext.Provider} creating it available somewhere where Jersey can
  * find it.
  *
- * <h4>Configuration</h4>
+ * <strong>Configuration</strong>
  * <p>
  * You need to configure Jersey to use this filter - set its init parameter
  * <code>com.sun.jersey.spi.container.ContainerRequestFilters</code>

--- a/cn-core/src/main/java/org/cloudname/core/LeaseHandle.java
+++ b/cn-core/src/main/java/org/cloudname/core/LeaseHandle.java
@@ -12,7 +12,7 @@ public interface LeaseHandle extends AutoCloseable {
      * @param data  data to write. Cannot be null.
      * @return true if data is written
      */
-    boolean writeLeaseData(final String data);
+    boolean writeData(final String data);
 
     /**
      * The full path of the lease.

--- a/cn-core/src/main/java/org/cloudname/core/LeaseType.java
+++ b/cn-core/src/main/java/org/cloudname/core/LeaseType.java
@@ -1,0 +1,14 @@
+package org.cloudname.core;
+
+/**
+ * Lease type. There are two kinds of leases:
+ * <ul>
+ *     <li>PERMANENT leases which will linger around forever until removed by some client.</li>
+ *     <li>TEMPORARY leases which will only exist as long as the client is connected to the
+ *     backend.</li>
+ * </ul>
+ */
+public enum LeaseType {
+    PERMANENT,
+    TEMPORARY
+}

--- a/cn-core/src/test/java/org/cloudname/core/BackendManagerTest.java
+++ b/cn-core/src/test/java/org/cloudname/core/BackendManagerTest.java
@@ -28,57 +28,38 @@ public class BackendManagerTest {
     private CloudnameBackend createBackend() {
         return new CloudnameBackend() {
             @Override
-            public LeaseHandle createTemporaryLease(CloudnamePath path, String data) {
+            public LeaseHandle createLease(LeaseType type, CloudnamePath path, String data) {
                 return null;
             }
 
             @Override
-            public boolean writeTemporaryLeaseData(CloudnamePath path, String data) {
+            public boolean writeLeaseData(CloudnamePath path, String data) {
                 return false;
             }
 
             @Override
-            public String readTemporaryLeaseData(CloudnamePath path) {
+            public String readLeaseData(CloudnamePath path) {
                 return null;
             }
 
             @Override
-            public void addTemporaryLeaseListener(CloudnamePath pathToWatch, LeaseListener listener) {
-
-            }
-
-            @Override
-            public void removeTemporaryLeaseListener(LeaseListener listener) {
-
-            }
-
-            @Override
-            public boolean createPermanantLease(CloudnamePath path, String data) {
+            public boolean removeLease(CloudnamePath path) {
                 return false;
             }
 
             @Override
-            public boolean removePermanentLease(CloudnamePath path) {
-                return false;
-            }
-
-            @Override
-            public boolean writePermanentLeaseData(CloudnamePath path, String data) {
-                return false;
-            }
-
-            @Override
-            public String readPermanentLeaseData(CloudnamePath path) {
-                return null;
-            }
-
-            @Override
-            public void addPermanentLeaseListener(CloudnamePath pathToObserver, LeaseListener listener) {
+            public void addLeaseCollectionListener(
+                    CloudnamePath pathToObserve, LeaseListener listener) {
 
             }
 
             @Override
-            public void removePermanentLeaseListener(LeaseListener listener) {
+            public void addLeaseListener(CloudnamePath pathToObserve, LeaseListener listener) {
+
+            }
+
+            @Override
+            public void removeLeaseListener(LeaseListener listener) {
 
             }
 

--- a/cn-memory/src/main/java/org/cloudname/backends/memory/MemoryLeaseHandle.java
+++ b/cn-memory/src/main/java/org/cloudname/backends/memory/MemoryLeaseHandle.java
@@ -29,8 +29,8 @@ public class MemoryLeaseHandle implements LeaseHandle {
     }
 
     @Override
-    public boolean writeLeaseData(final String data) {
-        return backend.writeTemporaryLeaseData(clientLeasePath, data);
+    public boolean writeData(final String data) {
+        return backend.writeLeaseData(clientLeasePath, data);
     }
 
     @Override
@@ -43,7 +43,7 @@ public class MemoryLeaseHandle implements LeaseHandle {
 
     @Override
     public void close() throws IOException {
-        backend.removeTemporaryLease(clientLeasePath);
+        backend.removeLease(clientLeasePath);
         expired.set(true);
     }
 }

--- a/cn-service/src/main/java/org/cloudname/service/ServiceHandle.java
+++ b/cn-service/src/main/java/org/cloudname/service/ServiceHandle.java
@@ -51,7 +51,7 @@ public class ServiceHandle implements AutoCloseable {
         if (!serviceData.addEndpoint(endpoint)) {
             return false;
         }
-        return this.leaseHandle.writeLeaseData(serviceData.toJsonString());
+        return this.leaseHandle.writeData(serviceData.toJsonString());
     }
 
     /**
@@ -63,7 +63,7 @@ public class ServiceHandle implements AutoCloseable {
         if (!serviceData.removeEndpoint(endpoint)) {
             return false;
         }
-        return this.leaseHandle.writeLeaseData(serviceData.toJsonString());
+        return this.leaseHandle.writeData(serviceData.toJsonString());
     }
 
     @Override

--- a/cn-service/src/test/java/org/cloudname/service/ServiceHandleTest.java
+++ b/cn-service/src/test/java/org/cloudname/service/ServiceHandleTest.java
@@ -20,7 +20,7 @@ public class ServiceHandleTest {
         final ServiceData serviceData = new ServiceData(new ArrayList<Endpoint>());
         final LeaseHandle handle = new LeaseHandle() {
             @Override
-            public boolean writeLeaseData(String data) {
+            public boolean writeData(String data) {
                 return true;
             }
 
@@ -57,7 +57,7 @@ public class ServiceHandleTest {
         final ServiceData serviceData = new ServiceData(Arrays.asList(ep1));
         final LeaseHandle handle = new LeaseHandle() {
             @Override
-            public boolean writeLeaseData(String data) {
+            public boolean writeData(String data) {
                 return false;
             }
 

--- a/cn-zookeeper/pom.xml
+++ b/cn-zookeeper/pom.xml
@@ -41,12 +41,6 @@
 
     <dependency>
       <groupId>org.apache.curator</groupId>
-      <artifactId>curator-recipes</artifactId>
-      <version>2.9.0</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.curator</groupId>
       <artifactId>curator-test</artifactId>
       <version>2.9.0</version>
       <scope>test</scope>

--- a/cn-zookeeper/src/main/java/org/cloudname/backends/zookeeper/ZooKeeperBackend.java
+++ b/cn-zookeeper/src/main/java/org/cloudname/backends/zookeeper/ZooKeeperBackend.java
@@ -7,17 +7,16 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.retry.ExponentialBackoffRetry;
 import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.data.Stat;
 import org.cloudname.core.CloudnameBackend;
 import org.cloudname.core.CloudnamePath;
 import org.cloudname.core.LeaseHandle;
 import org.cloudname.core.LeaseListener;
+import org.cloudname.core.LeaseType;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
@@ -31,15 +30,12 @@ import java.util.logging.Logger;
  */
 public class ZooKeeperBackend implements CloudnameBackend {
     private static final Logger LOG = Logger.getLogger(ZooKeeperBackend.class.getName());
-    private static final String TEMPORARY_ROOT = "/cn/temporary/";
-    private static final String PERMANENT_ROOT = "/cn/permanent/";
+    private static final String ZK_ROOT = "/cn/";
     private static final int CONNECTION_TIMEOUT_SECONDS = 30;
 
-    // PRNG for instance names. These will be "random enough" for instance identifiers
-    private final Random random = new Random();
     private final CuratorFramework curator;
-    private final Map<LeaseListener, NodeCollectionWatcher> clientListeners = new HashMap<>();
-    private final Map<LeaseListener, NodeCollectionWatcher> permanentListeners = new HashMap<>();
+    private final Map<LeaseListener, NodeCollectionWatcher> collectionListeners = new HashMap<>();
+    private final Map<LeaseListener, NodeCollectionWatcher> leaseListeners = new HashMap<>();
     private final Object syncObject = new Object();
 
     /**
@@ -60,65 +56,8 @@ public class ZooKeeperBackend implements CloudnameBackend {
     }
 
     @Override
-    public LeaseHandle createTemporaryLease(final CloudnamePath path, final String data) {
-        boolean created = false;
-        CloudnamePath tempInstancePath = null;
-        String tempZkPath = null;
-        while (!created) {
-            final long instanceId = random.nextLong();
-            tempInstancePath = new CloudnamePath(path, Long.toHexString(instanceId));
-            tempZkPath = TEMPORARY_ROOT + tempInstancePath.join('/');
-            try {
-
-                curator.create()
-                        .creatingParentContainersIfNeeded()
-                        .withMode(CreateMode.EPHEMERAL)
-                        .forPath(tempZkPath, data.getBytes(Charsets.UTF_8));
-                created = true;
-            } catch (final Exception ex) {
-                LOG.log(Level.WARNING, "Could not create client node at " + tempInstancePath, ex);
-            }
-        }
-        final CloudnamePath instancePath = tempInstancePath;
-        final String zkInstancePath = tempZkPath;
-        return new LeaseHandle() {
-            private AtomicBoolean closed = new AtomicBoolean(false);
-
-            @Override
-            public boolean writeLeaseData(final String data) {
-                if (closed.get()) {
-                    LOG.info("Attempt to write data to closed leased handle " + data);
-                    return false;
-                }
-                return writeTemporaryLeaseData(instancePath, data);
-            }
-
-            @Override
-            public CloudnamePath getLeasePath() {
-                if (closed.get()) {
-                    return null;
-                }
-                return instancePath;
-            }
-
-            @Override
-            public void close() throws IOException {
-                if (closed.get()) {
-                    return;
-                }
-                try {
-                    curator.delete().forPath(zkInstancePath);
-                    closed.set(true);
-                } catch (final Exception ex) {
-                    throw new IOException(ex);
-                }
-            }
-        };
-    }
-
-    @Override
-    public boolean writeTemporaryLeaseData(final CloudnamePath path, final String data) {
-        final String zkPath = TEMPORARY_ROOT + path.join('/');
+    public boolean writeLeaseData(final CloudnamePath path, final String data) {
+        final String zkPath = ZK_ROOT + path.join('/');
         try {
             final Stat nodeStat = curator.checkExists().forPath(zkPath);
             if (nodeStat == null) {
@@ -135,11 +74,11 @@ public class ZooKeeperBackend implements CloudnameBackend {
     }
 
     @Override
-    public String readTemporaryLeaseData(final CloudnamePath path) {
+    public String readLeaseData(final CloudnamePath path) {
         if (path == null) {
             return null;
         }
-        final String zkPath = TEMPORARY_ROOT + path.join('/');
+        final String zkPath = ZK_ROOT + path.join('/');
         try {
             curator.sync().forPath(zkPath);
             final byte[] bytes = curator.getData().forPath(zkPath);
@@ -150,20 +89,20 @@ public class ZooKeeperBackend implements CloudnameBackend {
         return null;
     }
 
-    private CloudnamePath toCloudnamePath(final String zkPath, final String pathPrefix) {
-        final String clientPath = zkPath.substring(pathPrefix.length());
+    private CloudnamePath toCloudnamePath(final String zkPath) {
+        final String clientPath = zkPath.substring(ZK_ROOT.length());
         final String[] elements = clientPath.split("/");
         return new CloudnamePath(elements);
     }
 
     @Override
-    public void addTemporaryLeaseListener(
+    public void addLeaseCollectionListener(
             final CloudnamePath pathToObserve, final LeaseListener listener) {
         // Ideally the PathChildrenCache class in Curator would be used here to keep track of the
         // changes but it is ever so slightly broken and misses most of the watches that ZooKeeper
         // triggers, ignores the mzxid on the nodes and generally makes a mess of things. Enter
         // custom code.
-        final String zkPath = TEMPORARY_ROOT + pathToObserve.join('/');
+        final String zkPath = ZK_ROOT + pathToObserve.join('/');
         try {
             curator.createContainers(zkPath);
             final NodeCollectionWatcher watcher = new NodeCollectionWatcher(
@@ -173,22 +112,22 @@ public class ZooKeeperBackend implements CloudnameBackend {
 
                         @Override
                         public void nodeCreated(final String path, final String data) {
-                            listener.leaseCreated(toCloudnamePath(path, TEMPORARY_ROOT), data);
+                            listener.leaseCreated(toCloudnamePath(path), data);
                         }
 
                         @Override
                         public void dataChanged(final String path, final String data) {
-                            listener.dataChanged(toCloudnamePath(path, TEMPORARY_ROOT), data);
+                            listener.dataChanged(toCloudnamePath(path), data);
                         }
 
                         @Override
                         public void nodeRemoved(final String path) {
-                            listener.leaseRemoved(toCloudnamePath(path, TEMPORARY_ROOT));
+                            listener.leaseRemoved(toCloudnamePath(path));
                         }
                     });
 
             synchronized (syncObject) {
-                clientListeners.put(listener, watcher);
+                collectionListeners.put(listener, watcher);
             }
         } catch (final Exception exception) {
             LOG.log(Level.WARNING, "Got exception when creating node watcher", exception);
@@ -196,40 +135,135 @@ public class ZooKeeperBackend implements CloudnameBackend {
     }
 
     @Override
-    public void removeTemporaryLeaseListener(final LeaseListener listener) {
+    public void addLeaseListener(final CloudnamePath leaseToObserve, final LeaseListener listener) {
+        try {
+            final String parentPath = ZK_ROOT + leaseToObserve.getParent().join('/');
+            final String fullPath = ZK_ROOT + leaseToObserve.join('/');
+            curator.createContainers(parentPath);
+            final NodeCollectionWatcher watcher = new NodeCollectionWatcher(
+                    curator.getZookeeperClient().getZooKeeper(),
+                    parentPath,
+                    new NodeWatcherListener() {
+
+                        @Override
+                        public void nodeCreated(final String path, final String data) {
+                            if (path.equals(fullPath)) {
+                                listener.leaseCreated(toCloudnamePath(path), data);
+                            }
+                        }
+
+                        @Override
+                        public void dataChanged(final String path, final String data) {
+                            if (path.equals(fullPath)) {
+                                listener.dataChanged(toCloudnamePath(path), data);
+                            }
+                        }
+
+                        @Override
+                        public void nodeRemoved(final String path) {
+                            if (path.equals(fullPath)) {
+                                listener.leaseRemoved(toCloudnamePath(path));
+                            }
+                        }
+                    });
+
+            synchronized (syncObject) {
+                leaseListeners.put(listener, watcher);
+            }
+        } catch (final Exception exception) {
+            LOG.log(Level.WARNING, "Got exception when creating node watcher", exception);
+        }
+    }
+
+    @Override
+    public void removeLeaseListener(final LeaseListener listener) {
         synchronized (syncObject) {
-            final NodeCollectionWatcher watcher = clientListeners.get(listener);
-            if (watcher != null) {
-                clientListeners.remove(listener);
-                watcher.shutdown();
+            final NodeCollectionWatcher collectionWatcher = collectionListeners.get(listener);
+            if (collectionWatcher != null) {
+                collectionListeners.remove(listener);
+                collectionWatcher.shutdown();
+            }
+            final NodeCollectionWatcher leaseWatcher = leaseListeners.get(listener);
+            if (leaseWatcher != null) {
+                leaseListeners.remove(listener);
+                leaseWatcher.shutdown();
             }
         }
     }
 
     @Override
-    public boolean createPermanantLease(final CloudnamePath path, final String data) {
-        final String zkPath = PERMANENT_ROOT + path.join('/');
+    public LeaseHandle createLease(
+            final LeaseType type, final CloudnamePath path, final String data) {
+        if (type == null || path == null || data == null) {
+            return null;
+        }
+
+        final String zkPath = ZK_ROOT + path.join('/');
         try {
             curator.sync().forPath(zkPath);
             final Stat nodeStat = curator.checkExists().forPath(zkPath);
             if (nodeStat == null) {
-                curator.create()
+                final CreateMode mode = (type == LeaseType.PERMANENT
+                        ? CreateMode.PERSISTENT : CreateMode.EPHEMERAL);
+
+                final String returnedPath = curator.create()
                         .creatingParentContainersIfNeeded()
+                        .withMode(mode)
                         .forPath(zkPath, data.getBytes(Charsets.UTF_8));
-                return true;
+
+                if (returnedPath == null) {
+                    LOG.warning("Could not create node for path " + path
+                            + " - Curator returned null on create()");
+                    return null;
+                }
+                return new LeaseHandle() {
+                    private AtomicBoolean closed = new AtomicBoolean(false);
+
+                    @Override
+                    public boolean writeData(final String data) {
+                        if (closed.get()) {
+                            LOG.info("Attempt to write data to closed leased handle " + data);
+                            return false;
+                        }
+                        return writeLeaseData(path, data);
+                    }
+
+                    @Override
+                    public CloudnamePath getLeasePath() {
+                        if (closed.get()) {
+                            return null;
+                        }
+                        return path;
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        if (type == LeaseType.PERMANENT || closed.get()) {
+                            return;
+                        }
+                        try {
+                            curator.delete().forPath(zkPath);
+                            closed.set(true);
+                        } catch (final Exception ex) {
+                            throw new IOException(ex);
+                        }
+                    }
+                };
             }
-            LOG.log(Level.INFO, "Attempt to create permanent node at " + path
+
+            LOG.log(Level.INFO, "Attempt to create node at " + path
                     + " with data " + data + " but it already exists");
+
         } catch (final Exception ex) {
-            LOG.log(Level.WARNING, "Got exception creating parent container for permanent lease"
+            LOG.log(Level.WARNING, "Got exception creating parent container for lease"
                     + " for lease " + path + " with data " + data, ex);
         }
-        return false;
+        return null;
     }
 
     @Override
-    public boolean removePermanentLease(final CloudnamePath path) {
-        final String zkPath = PERMANENT_ROOT + path.join('/');
+    public boolean removeLease(final CloudnamePath path) {
+        final String zkPath = ZK_ROOT + path.join('/');
         try {
             final Stat nodeStat = curator.checkExists().forPath(zkPath);
             if (nodeStat != null) {
@@ -240,115 +274,18 @@ public class ZooKeeperBackend implements CloudnameBackend {
             }
             return false;
         } catch (final Exception ex) {
-            LOG.log(Level.WARNING, "Got error removing permanent lease for lease " + path, ex);
+            LOG.log(Level.WARNING, "Got error removing node for lease " + path, ex);
             return false;
-        }
-    }
-
-    @Override
-    public boolean writePermanentLeaseData(final CloudnamePath path, final String data) {
-        final String zkPath = PERMANENT_ROOT + path.join('/');
-        try {
-            curator.sync().forPath(zkPath);
-            final Stat nodeStat = curator.checkExists().forPath(zkPath);
-            if (nodeStat == null) {
-                LOG.log(Level.WARNING, "Can't write permanent lease data for lease " + path
-                        + " with data " + data + " since the lease doesn't exist");
-                return false;
-            }
-            curator.setData()
-                    .withVersion(nodeStat.getVersion())
-                    .forPath(zkPath, data.getBytes(Charsets.UTF_8));
-        } catch (final Exception ex) {
-            LOG.log(Level.WARNING, "Got exception writing permanent lease data for " + path
-                    + " with data " + data, ex);
-            return false;
-        }
-        return true;
-    }
-
-    @Override
-    public String readPermanentLeaseData(final CloudnamePath path) {
-        final String zkPath = PERMANENT_ROOT + path.join('/');
-        try {
-            curator.sync().forPath(zkPath);
-            final byte[] bytes = curator.getData().forPath(zkPath);
-            return new String(bytes, Charsets.UTF_8);
-        } catch (final Exception ex) {
-            if (ex instanceof KeeperException.NoNodeException) {
-                // OK - nothing to worry about
-                return null;
-            }
-            LOG.log(Level.WARNING, "Got exception reading permanent lease data for " + path, ex);
-            return null;
-        }
-    }
-
-    @Override
-    public void addPermanentLeaseListener(
-            final CloudnamePath pathToObserve, final LeaseListener listener) {
-        try {
-
-            final String parentPath = PERMANENT_ROOT + pathToObserve.getParent().join('/');
-            final String fullPath = PERMANENT_ROOT + pathToObserve.join('/');
-            curator.createContainers(parentPath);
-            final NodeCollectionWatcher watcher = new NodeCollectionWatcher(
-                    curator.getZookeeperClient().getZooKeeper(),
-                    parentPath,
-                    new NodeWatcherListener() {
-
-                        @Override
-                        public void nodeCreated(final String path, final String data) {
-                            if (path.equals(fullPath)) {
-                                listener.leaseCreated(toCloudnamePath(path, PERMANENT_ROOT), data);
-                            }
-                        }
-
-                        @Override
-                        public void dataChanged(final String path, final String data) {
-                            if (path.equals(fullPath)) {
-                                listener.dataChanged(toCloudnamePath(path, PERMANENT_ROOT), data);
-                            }
-                        }
-
-                        @Override
-                        public void nodeRemoved(final String path) {
-                            if (path.equals(fullPath)) {
-                                listener.leaseRemoved(toCloudnamePath(path, PERMANENT_ROOT));
-                            }
-                        }
-                    });
-
-            synchronized (syncObject) {
-                permanentListeners.put(listener, watcher);
-            }
-        } catch (final Exception exception) {
-            LOG.log(Level.WARNING, "Got exception when creating node watcher", exception);
-        }
-    }
-
-    @Override
-    public void removePermanentLeaseListener(final LeaseListener listener) {
-        synchronized (syncObject) {
-            final NodeCollectionWatcher watcher = permanentListeners.get(listener);
-            if (watcher != null) {
-                permanentListeners.remove(listener);
-                watcher.shutdown();
-            }
         }
     }
 
     @Override
     public void close() {
         synchronized (syncObject) {
-            for (final NodeCollectionWatcher watcher : clientListeners.values()) {
-                watcher.shutdown();
-            }
-            clientListeners.clear();
-            for (final NodeCollectionWatcher watcher : permanentListeners.values()) {
-                watcher.shutdown();
-            }
-            permanentListeners.clear();
+            collectionListeners.values().forEach(NodeCollectionWatcher::shutdown);
+            collectionListeners.clear();
+            leaseListeners.values().forEach(NodeCollectionWatcher::shutdown);
+            leaseListeners.clear();
         }
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
       <name>Bjorn Borud</name>
       <email>bborud@gmail.com</email>
     </developer>
+    <developer>
+      <id>stalehd</id>
+      <name>Staale Dahl</name>
+      <email>stalehd@gmail.com</email>
+    </developer>
   </developers>
 
   <scm>
@@ -63,6 +68,18 @@
     <module>flags</module>
     <module>idgen</module>
   </modules>
+
+  <profiles>
+    <profile>
+      <id>disable-java8-doclint</id>
+      <activation>
+        <jdk>[1.8,)</jdk>
+      </activation>
+      <properties>
+        <additionalparam>-Xdoclint:none</additionalparam>
+      </properties>
+    </profile>
+  </profiles>
 
   <build>
     <plugins>
@@ -110,6 +127,18 @@
 
     </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.10.3</version>
+        <configuration>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <pluginRepositories>
     <pluginRepository>


### PR DESCRIPTION
Merge the permanent/temporary methods into a single coherent set. This makes
the interface a bit more flexible since you can listen on collections of
leases of both kinds. Since the backend doesn't have to implement naming
of temporary leases and store all of the leases in the same name space the
various implementations are a lot simpler as well.

In addition - javadoc reporting pluging added. Some of the issues reported
as warnings was fixed but in the end linting was turned off. It should be
turned on later on when there's been a general cleanup. Run with
mvn javadoc:aggregate to generate javadoc locally.